### PR TITLE
Create a theme button in django admin panel

### DIFF
--- a/zubhub_backend/zubhub/zubhub/admin.py
+++ b/zubhub_backend/zubhub/zubhub/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import AdminSettings, Hero, Privacy, FAQ, Help
+from .models import AdminSettings, Hero, Privacy, FAQ, Help, Theme
 
 ## these models are imported to be unregsitered
 from django_summernote.models import Attachment
@@ -45,12 +45,19 @@ class FAQAdmin(SummernoteModelAdmin):
     class Media:
         js = ('http://code.jquery.com/jquery-3.1.1.js', 'js/main.js',)
 
+class ThemeAdmin(SummernoteModelAdmin):
+    summernote_fields = ('theme',)
+
+    class Media:
+        js = ('http://code.jquery.com/jquery-3.1.1.js', 'js/main.js',)
+
 
 admin.site.register(AdminSettings, AdminSettingsAdmin)
 admin.site.register(Hero, HeroAdmin)
 admin.site.register(Privacy, PrivacyAdmin)
 admin.site.register(Help, HelpAdmin)
 admin.site.register(FAQ, FAQAdmin)
+admin.site.register(Theme, ThemeAdmin)
 
 ## Unregister some default and third-party models
 admin.site.unregister(Attachment)

--- a/zubhub_backend/zubhub/zubhub/models.py
+++ b/zubhub_backend/zubhub/zubhub/models.py
@@ -1,3 +1,4 @@
+from distutils.command.clean import clean
 import uuid
 from math import floor
 from django.utils import timezone
@@ -6,6 +7,7 @@ from django.db import models
 from django.core.validators import FileExtensionValidator
 from django.utils.text import slugify
 from .utils import MediaStorage, get_upload_path, clean_summernote_html
+
 
 
 class AdminSettings(models.Model):
@@ -117,3 +119,15 @@ class FAQ(models.Model):
         self.question = clean_summernote_html(self.question)
         self.answer = clean_summernote_html(self.answer)
         super().save(*args, **kwargs)
+
+class Theme(models.Model):
+    theme = models.CharField(max_length=50)
+
+    class Meta:
+        verbose_name = "Theme"
+        verbose_name_plural = "Themes"
+
+    def save(self, *args, **kwargs):
+        self.theme = clean_summernote_html(self.theme)
+        super().save(*args, **kwargs)
+    

--- a/zubhub_backend/zubhub/zubhub/serializers.py
+++ b/zubhub_backend/zubhub/zubhub/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import Hero, FAQ, Help, Privacy
+from .models import Hero, FAQ, Help, Privacy, Theme
 
 
 class HeroSerializer(serializers.ModelSerializer):
@@ -46,4 +46,12 @@ class FAQListSerializer(serializers.ModelSerializer):
         fields = [
             "question",
             "answer"
+        ]
+
+class ThemeSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Theme
+        fields = [
+            "theme",
         ]

--- a/zubhub_backend/zubhub/zubhub/urls.py
+++ b/zubhub_backend/zubhub/zubhub/urls.py
@@ -48,7 +48,7 @@ if settings.DEFAULT_BACKEND_DOMAIN.startswith("localhost"):
     from rest_auth.registration.urls import VerifyEmailView
     from zubhub.views import (UploadFileAPIView, DeleteFileAPIView,
                             HeroAPIView, HelpAPIView, PrivacyAPIView, 
-                            FAQAPIView, SigGenAPIView, UploadFileToLocalAPIView, 
+                            FAQAPIView, ThemeAPIView, SigGenAPIView, UploadFileToLocalAPIView, 
                             MarkdownToHtmlAPIView, MediaSchemaAPIView, WebSchemaAPIView)
 
     schema_url_patterns = [
@@ -66,6 +66,7 @@ if settings.DEFAULT_BACKEND_DOMAIN.startswith("localhost"):
             path('api/help/', HelpAPIView.as_view()),
             path('api/privacy/', PrivacyAPIView.as_view()),
             path('api/faqs/', FAQAPIView.as_view()),
+            path('api/faqs/', ThemeAPIView.as_view()),
             path('api/signature/', SigGenAPIView)
             ]
 

--- a/zubhub_backend/zubhub/zubhub/views.py
+++ b/zubhub_backend/zubhub/zubhub/views.py
@@ -1,7 +1,7 @@
 from math import floor
 import uuid
-from .serializers import HeroSerializer, FAQListSerializer, HelpSerializer, PrivacySerializer
-from .models import Hero, FAQ, Privacy, Help, AdminSettings
+from .serializers import HeroSerializer, FAQListSerializer, HelpSerializer, PrivacySerializer, ThemeSerializer
+from .models import Hero, FAQ, Privacy, Help, AdminSettings, Theme
 from .utils import delete_file_from_media_server, upload_file_to_media_server, get_sig
 from projects.permissions import PostUserRateThrottle, GetUserRateThrottle, SustainedRateThrottle
 from rest_framework.permissions import IsAuthenticated
@@ -240,6 +240,21 @@ class FAQAPIView(ListAPIView):
     permission_classes = [AllowAny]
     throttle_classes = [GetUserRateThrottle, SustainedRateThrottle]
 
+class ThemeAPIView(RetrieveAPIView):
+    """
+    Get "Theme Zubhub".
+    """
+
+    queryset = Theme.objects.all()
+    serializer_class = ThemeSerializer
+    permission_classes = [AllowAny]
+    throttle_classes = [GetUserRateThrottle, SustainedRateThrottle]
+
+    def get_object(self):
+        obj = self.get_queryset()[:1]
+        if obj:
+            return obj[0]
+        return None
 
 
 @api_view(['GET'])


### PR DESCRIPTION
Allow basic theme changes to be done from Django Admin

In progress for issue #343, Do not merge yet.

##Task
- [ ] Extract colors, fonts and Font sizes being used and convert them to CSS variables. These values are in CSS files as well as embedded in JS. 
- [ ] Allow modification of these variables from the backend from ZubHub settings. Add a new item called "Theme" in the area below.

## Changes
- [ ] Identify one color variable you can modify
- [ ] Test that it changes the appearance of the web when you change the value
- [x] Create a Button for it in then admin panel
- [ ] Then make the Button to modify the color value